### PR TITLE
Fix gemspec for use with :path option in Bundler.

### DIFF
--- a/libxslt-ruby.gemspec
+++ b/libxslt-ruby.gemspec
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require 'rake'
+
 # Determine the current version of the software
 version = File.read('ext/libxslt/version.h').match(/\s*RUBY_LIBXSLT_VERSION\s*['"](\d.+)['"]/)[1]
 


### PR DESCRIPTION
FileList is a part of Rake, and Bundler needs the require 'rake' in the gemspec
