### PR TITLE
Fix Ruby 1.9.3-preview1 libxml 2.7.3 (OS X Lion) conflicting OnigUChar re

### DIFF
--- a/ext/libxslt/libxslt.h
+++ b/ext/libxslt/libxslt.h
@@ -3,6 +3,7 @@
 /* Please see the LICENSE file for copyright and distribution information */
 
 #include <libxml/parser.h>
+#include <libxml/debugXML.h>
 
 #ifndef __RUBY_LIBXSLT_H__
 #define __RUBY_LIBXSLT_H__
@@ -14,7 +15,6 @@
 #include <rubyio.h>
 #endif
 
-#include <libxml/debugXML.h>
 #include <ruby_libxml.h>
 
 #include <libxslt/extra.h>


### PR DESCRIPTION
Fix Ruby 1.9.3-preview1 libxml 2.7.3 (OS X Lion) conflicting OnigUChar redefinition.

This was the error I received prior to this fix:

```
compiling ../../../../ext/libxslt/libxslt.c
In file included from /usr/include/libxml2/libxml/parser.h:798,
                 from ../../../../ext/libxslt/libxslt.h:15,
                 from ../../../../ext/libxslt/libxslt.c:5:
/usr/include/libxml2/libxml/encoding.h:41: error: conflicting types for ‘OnigUChar’
/Users/travis/.rvm/rubies/ruby-1.9.3-preview1/include/ruby-1.9.1/ruby/oniguruma.h:110: error: previous declaration of ‘OnigUChar’ was here
```

However, the actual issue was line 107 in oniguruma.h which effectively "aliases" OnigUChar as UChar:

```
#ifndef ONIG_ESCAPE_UCHAR_COLLISION
#define UChar OnigUChar
#endif
```

Including libxml/parser.h before ruby headers prevents this from happening (although, honestly, I don't see how)

This is tested on OS X Lion (libxml2 2.7.3) and ruby 1.9.3-preview1 and Gentoo Linux (libxml2 2.7.8) and ruby 1.9.3-preview1
