### PR TITLE
Gem installation fails on Linux

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -44,6 +44,16 @@ while binaries for libxslt and libexslt areprovided in the
 libxslt-ruby bindings.
 
 
+Installation from source:
+
+ruby ext/libxslt/extconf.rb
+make
+sudo make install
+
+gem build xslt-ruby.gemspec
+gem install xslt-ruby-1.1.1.gem
+
+
 == USAGE
 
 For in-depth information about using libxslt-ruby please refer

--- a/README.rdoc
+++ b/README.rdoc
@@ -50,8 +50,8 @@ ruby ext/libxslt/extconf.rb
 make
 sudo make install
 
-gem build xslt-ruby.gemspec
-gem install xslt-ruby-1.1.1.gem
+gem build libxslt-ruby.gemspec
+gem install libxslt-ruby-1.1.1.gem
 
 
 == USAGE

--- a/ext/libxslt/extconf.rb
+++ b/ext/libxslt/extconf.rb
@@ -126,12 +126,12 @@ end
 
 RUBY_VERSION =~ /(\d+.\d+)/
 minor_version = $1
-paths = ["#{gem_spec.full_gem_path}/lib", 
+paths = ["#{gem_spec.full_gem_path}/lib",
          "#{gem_spec.full_gem_path}/lib/#{minor_version}",
          "#{gem_spec.full_gem_path}/ext/libxml"]
 
 # No need to link xml_ruby on OS X
-unless RbConfig::CONFIG['host_os'].match(/darwin/)
+unless RbConfig::CONFIG['host_os'].match(/darwin|linux/)
   # Hack to make sure ruby library is *after* xml_ruby library
   $LIBS = "#{$LIBRUBYARG_STATIC} #{$LIBS}"
 

--- a/libxslt-ruby.gemspec
+++ b/libxslt-ruby.gemspec
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'date'
 
 # Determine the current version of the software
 version = File.read('ext/libxslt/version.h').match(/\s*RUBY_LIBXSLT_VERSION\s*['"](\d.+)['"]/)[1]


### PR DESCRIPTION
Following the suggested installation instruction from the `README.md` did not work on my Ubuntu 18.04 LTS box. It failed complaining that `libxml-ruby` is not installed (which it is). The trouble seemed to be related to something already addressed in #11 as well as in `tonyfg/libxslt-ruby.git`

Issuing on `xml4r/libxslt-ruby` `master` a

    ruby ext/libxslt/extconf.rb

also resulted in the error 

    extconf failure: %s
          Need libxml-ruby
          Please install libxml-ruby or specify the path to the gem via:
            --with-libxml-ruby=/path/to/libxml-ruby gem

Commit 2ed8d5550f9665e42a21b8407213150e95d8f0ef from `tonyfg/libxslt-ruby.git` fixes this with extending the already existing hack for `darwin` to `linux`

After those changes, a `gem build libxslt-ruby.gemspec` fails with

    Invalid gemspec in [libxslt-ruby.gemspec]: uninitialized constant Gem::Specification::DateTime
    Did you mean?  Gem::Specification::DateLike
    ERROR:  Error loading gemspec. Aborting.

This is fixed with commit 69bd5cc3fcd047960ed659e1542447f8a23ad425 

Added documentation on how to build and install from source with 531d38f3c72ba8877f859521f2366abe0ced64cd and cf69596439151aa5fec86472f6f95305d605c809 

