### PR TITLE
Add include <libxml/xpathInternal.h> for current libxml.

### DIFF
--- a/ext/libxslt/ruby_exslt.h
+++ b/ext/libxslt/ruby_exslt.h
@@ -1,6 +1,7 @@
 #ifndef __RUBY_EXSLT__
 #define __RUBY_EXSLT__
 
+#include <libxml/xpathInternals.h>
 #include <libxslt/extensions.h>
 
 void ruby_init_exslt(void);


### PR DESCRIPTION
Hello, 

I got the following error on building libxslt-ruby with libxml2 `2.12.7`.

Some functions (valuePop & valuePush) are not exported on default with libxml2 `>= 2.2.10`.

I made a 1-line patch and confirmed the build successfully.

```
Building native extensions. This could take a while...
ERROR:  Error installing libxslt-ruby:
	ERROR: Failed to build gem native extension.

    current directory: /home/sugi/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/libxslt-ruby-1.2.0/ext/libxslt
/home/sugi/.rbenv/versions/3.3.4/bin/ruby extconf.rb
/home/sugi/.rbenv/versions/3.3.4/bin/ruby: warning: shebang line ending with \r may cause problems
checking for xmlXPtrNewRange() in -lxml2... yes
checking for libxml/xmlversion.h... no
checking for libxml/xmlversion.h in /opt/include/libxml2,/usr/local/include/libxml2,/usr/include/libxml2... yes
checking for xsltApplyStylesheet() in -lxslt... yes
checking for xslt.h... no
checking for xslt.h in /opt/include/libxslt,/usr/local/include/libxslt,/usr/include/libxslt... yes
checking for exsltRegisterAll() in -lexslt... yes
checking for exslt.h... no
checking for exslt.h in /opt/include/libexslt,/usr/local/include/libexslt,/usr/include/libexslt... yes
creating extconf.h
creating Makefile

current directory: /home/sugi/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/libxslt-ruby-1.2.0/ext/libxslt
make DESTDIR\= sitearchdir\=./.gem.20240818-3459719-sfpwtc sitelibdir\=./.gem.20240818-3459719-sfpwtc clean

current directory: /home/sugi/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/libxslt-ruby-1.2.0/ext/libxslt
make DESTDIR\= sitearchdir\=./.gem.20240818-3459719-sfpwtc sitelibdir\=./.gem.20240818-3459719-sfpwtc
compiling libxslt.c
compiling ruby_exslt.c
ruby_exslt.c: In function ‘ruby_xslt_module_function_callback’:
ruby_exslt.c:47:50: error: implicit declaration of function ‘valuePop’ [-Wimplicit-function-declaration]
   47 |     args[i] = rxml_xpath_to_value(ctxt->context, valuePop(ctxt));
      |                                                  ^~~~~~~~
ruby_exslt.c:47:50: error: passing argument 2 of ‘rxml_xpath_to_value’ makes pointer from integer without a cast [-Wint-conversion]
   47 |     args[i] = rxml_xpath_to_value(ctxt->context, valuePop(ctxt));
      |                                                  ^~~~~~~~~~~~~~
      |                                                  |
      |                                                  int
In file included from /home/sugi/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/libxml-ruby-5.0.3/ext/libxml/ruby_libxml.h:32,
                 from libxslt.h:18,
                 from ruby_exslt.c:3:
/home/sugi/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/libxml-ruby-5.0.3/ext/libxml/ruby_xml_xpath.h:12:47: note: expected ‘xmlXPathObjectPtr’ {aka ‘struct _xmlXPathObject *’} but argument is of type ‘int’
   12 | VALUE rxml_xpath_to_value(xmlXPathContextPtr, xmlXPathObjectPtr);
      |                                               ^~~~~~~~~~~~~~~~~
ruby_exslt.c:50:3: error: implicit declaration of function ‘valuePush’ [-Wimplicit-function-declaration]
   50 |   valuePush(ctxt, rxml_xpath_from_value(
      |   ^~~~~~~~~
ruby_exslt.c: In function ‘ruby_init_exslt’:
ruby_exslt.c:140:1: warning: old-style function definition [-Wold-style-definition]
  140 | ruby_init_exslt() {
      | ^~~~~~~~~~~~~~~
At top level:
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
make: *** [Makefile:248: ruby_exslt.o] Error 1

make failed, exit code 2

Gem files will remain installed in /home/sugi/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/libxslt-ruby-1.2.0 for inspection.
Results logged to /home/sugi/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/extensions/x86_64-linux/3.3.0/libxslt-ruby-1.2.0/gem_make.out
```