### PR TITLE
Fix build issue with libxml2 2.14+.

### DIFF
--- a/ext/libxslt/extconf.rb
+++ b/ext/libxslt/extconf.rb
@@ -17,9 +17,9 @@ dir_config('xml2')
 dir_config('xslt')
 dir_config('exslt')
 
-unless (have_library('xml2', 'xmlXPtrNewRange') or
-        have_library('libxml2', 'xmlXPtrNewRange') or
-        find_library('xml2', 'xmlXPtrNewRange', '/opt/lib', '/usr/local/lib', '/usr/lib')) and
+unless (have_library('xml2', 'xmlXPtrNewContext') or
+        have_library('libxml2', 'xmlXPtrNewContext') or
+        find_library('xml2', 'xmlXPtrNewContext', '/opt/lib', '/usr/local/lib', '/usr/lib')) and
        (have_header('libxml/xmlversion.h') or
         find_header('libxml/xmlversion.h',
                     '/opt/include/libxml2',


### PR DESCRIPTION
Hello,

I found a build issue with libxml2 2.14 above.

## Summary

`extconf.rb` uses `xmlXPtrNewRange` as a probe function to detect the presence of libxml2. This function was removed in libxml2 2.14.0 (March 2025) as part of the XPointer range/point extension cleanup, causing the library detection to fail and the gem build to abort with:

```
checking for xmlXPtrNewRange() in -lxml2... no
checking for xmlXPtrNewRange() in -llibxml2... no
checking for xmlXPtrNewRange() in -lxml2... no
*** extconf failure: Cannot find libxml2.
```

This affects all systems with libxml2 >= 2.14.0, including Debian forky (testing, which ships libxml2 2.15.x).

## Fix

Replace the probe function with `xmlXPtrNewContext`, which remains in libxml2's XPointer API. The function is not used in the gem's C source code itself — it is only referenced in `extconf.rb` for library detection.

## References

- libxml2 2.14.0 release notes: https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.14.0
- libxml2 XPointer API (current): https://gnome.pages.gitlab.gnome.org/libxml2/devhelp/libxml2-xpointer.html